### PR TITLE
Allow Platform-specific Custom Power Operations

### DIFF
--- a/airupfx/airupfx-power/src/freebsd.rs
+++ b/airupfx/airupfx-power/src/freebsd.rs
@@ -26,6 +26,10 @@ impl PowerManager for Power {
         crate::unix::prepare().await;
         airupfx_process::reload_image()
     }
+
+    async fn custom(&self, _: &str) -> std::io::Result<Infallible> {
+        self.reboot().await
+    }
 }
 
 fn reboot(cmd: libc::c_int) -> std::io::Result<Infallible> {

--- a/airupfx/airupfx-power/src/lib.rs
+++ b/airupfx/airupfx-power/src/lib.rs
@@ -51,6 +51,12 @@ pub trait PowerManager: Send + Sync {
     /// # Errors
     /// An `Err(_)` is returned if it failed to perform an userspace reboot.
     async fn userspace(&self) -> std::io::Result<Infallible>;
+
+    /// Performs a custom power operation.
+    ///
+    /// # Errors
+    /// An `Err(_)` is returned if it failed to perform the specific power operation.
+    async fn custom(&self, cmd: &str) -> std::io::Result<Infallible>;
 }
 
 /// A fallback implementation of `AirupFX` power management.
@@ -74,6 +80,10 @@ impl PowerManager for Fallback {
     }
 
     async fn userspace(&self) -> std::io::Result<Infallible> {
+        Self::halt_process();
+    }
+
+    async fn custom(&self, _: &str) -> std::io::Result<Infallible> {
         Self::halt_process();
     }
 }

--- a/airupfx/airupfx-power/src/linux.rs
+++ b/airupfx/airupfx-power/src/linux.rs
@@ -33,6 +33,10 @@ impl PowerManager for Power {
         crate::unix::prepare().await;
         airupfx_process::reload_image()
     }
+
+    async fn custom(&self, _: &str) -> std::io::Result<Infallible> {
+        self.reboot().await
+    }
 }
 
 fn reboot(cmd: libc::c_int, arg: Option<NonNull<c_void>>) -> std::io::Result<()> {

--- a/airupfx/airupfx-power/src/macos.rs
+++ b/airupfx/airupfx-power/src/macos.rs
@@ -37,6 +37,10 @@ impl PowerManager for Power {
         crate::unix::prepare().await;
         airupfx_process::reload_image()
     }
+
+    async fn custom(&self, _: &str) -> std::io::Result<Infallible> {
+        self.reboot().await
+    }
 }
 
 fn system_reboot(cmd: libc::c_int) -> std::io::Result<Infallible> {


### PR DESCRIPTION
# Introduction
Some platforms support power operations that aren't supported by other platforms and can be integrated into Airup's architecture for system stability, like Linux's `kexec`.

# Unresolved Questions
 * How should the API be designed?
 * The feature introduces a new error kind which is caused by parse failure of the command string. How to design the API to avoid terminating `airupd` process from failure? Should we use `std::io::Error` or our custom error type?