### PR TITLE
Implement #38: Add `chroot()` support

### DIFF
--- a/airup-sdk/src/files/service.rs
+++ b/airup-sdk/src/files/service.rs
@@ -106,6 +106,9 @@ pub struct Env {
     /// Working directory to start the service.
     pub working_dir: Option<PathBuf>,
 
+    /// Root directory to start the service.
+    pub root_dir: Option<PathBuf>,
+
     /// Environment variables to execute for the service.
     ///
     /// If a value is set to `null`, the environment variable gets removed if it exists.
@@ -125,6 +128,7 @@ impl Default for Env {
             stdout: Stdio::Log,
             stderr: Stdio::Log,
             working_dir: None,
+            root_dir: None,
             vars: HashMap::default(),
         }
     }

--- a/airupd/src/supervisor/task/mod.rs
+++ b/airupd/src/supervisor/task/mod.rs
@@ -223,6 +223,7 @@ async fn ace_environment(
         .stderr(to_ace(env.stderr.clone(), 2))
         .clear_vars(env.clear_vars)
         .vars::<String, _, String>(vars)
+        .root_dir::<PathBuf, _>(env.root_dir.clone())
         .working_dir::<PathBuf, _>(env.working_dir.clone())
         .setsid(true);
 

--- a/airupfx/airupfx-process/src/lib.rs
+++ b/airupfx/airupfx-process/src/lib.rs
@@ -203,6 +203,7 @@ pub struct CommandEnv {
     pub setsid: bool,
     pub cpu_limit: Option<u64>,
     pub mem_limit: Option<u64>,
+    pub root_dir: Option<PathBuf>,
 }
 impl CommandEnv {
     #[inline]
@@ -267,6 +268,13 @@ impl CommandEnv {
         self
     }
 
+    #[inline]
+    pub fn root_dir<P: Into<PathBuf>, T: Into<Option<P>>>(&mut self, value: T) -> &mut Self {
+        self.root_dir = value.into().map(Into::into);
+        self
+    }
+
+    #[inline]
     pub fn login<'a, U: Into<Option<&'a str>>>(&mut self, name: U) -> std::io::Result<&mut Self> {
         if let Some(x) = name.into() {
             sys::command_login(self, x)?;

--- a/airupfx/airupfx-process/src/unix.rs
+++ b/airupfx/airupfx-process/src/unix.rs
@@ -13,7 +13,9 @@ use std::{
     cmp,
     collections::HashMap,
     convert::Infallible,
-    os::unix::process::CommandExt as _,
+    ffi::CStr,
+    os::unix::{ffi::OsStrExt, process::CommandExt as _},
+    path::Path,
     sync::{OnceLock, RwLock},
 };
 use tokio::{signal::unix::SignalKind, sync::watch};
@@ -27,6 +29,21 @@ pub trait CommandExt {
 
     /// View [`std::os::unix::process::CommandExt::groups`].
     fn groups(&mut self, groups: &[libc::gid_t]) -> &mut Self;
+
+    /// View [`std::os::unix::process::CommandExt::uid`].
+    ///
+    /// This is stable in Rust, however, it prevents some functions requiring root, like `groups` from working, so here
+    /// a version using `.pre_exec()` is provided.
+    fn uid(&mut self, uid: libc::uid_t) -> &mut Self;
+
+    /// Chroots to the specified directory.
+    fn root_dir(&mut self, path: &Path) -> &mut Self;
+
+    /// View [`std::process::Command::current_dir`].
+    ///
+    /// This is stable in Rust, however, it works weirdly when combined with `root_dir`, since it is applied earilier than
+    /// any `.pre_exec()`.
+    fn current_dir(&mut self, path: &Path) -> &mut Self;
 }
 impl CommandExt for std::process::Command {
     fn setsid(&mut self) -> &mut Self {
@@ -44,9 +61,7 @@ impl CommandExt for std::process::Command {
     }
 
     fn groups(&mut self, groups: &[libc::gid_t]) -> &mut Self {
-        fn setgroups(_groups: &[libc::gid_t]) -> std::io::Result<()> {
-            /*
-            This is temporarily commented, because `setuid` always runs ahead of `setgroups`, which caused this to always fail.
+        fn setgroups(groups: &[libc::gid_t]) -> std::io::Result<()> {
             unsafe {
                 let pgid = libc::setgroups(groups.len() as _, groups.as_ptr()) as _;
                 match pgid {
@@ -55,12 +70,47 @@ impl CommandExt for std::process::Command {
                     _ => unreachable!(),
                 }
             }
-            */
-            Ok(())
         }
 
         let groups = groups.to_vec();
         unsafe { self.pre_exec(move || setgroups(&groups[..])) }
+    }
+
+    fn uid(&mut self, uid: libc::uid_t) -> &mut Self {
+        fn setuid(uid: libc::uid_t) -> std::io::Result<()> {
+            unsafe {
+                match libc::setuid(uid) {
+                    0 => Ok(()),
+                    -1 => Err(std::io::Error::last_os_error()),
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        unsafe { self.pre_exec(move || setuid(uid)) }
+    }
+
+    fn root_dir(&mut self, path: &Path) -> &mut Self {
+        fn chroot(path: &Path) -> std::io::Result<()> {
+            unsafe {
+                let s = CStr::from_bytes_with_nul(path.as_os_str().as_bytes())
+                    .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?
+                    .as_ptr();
+                match libc::chroot(s) {
+                    0 => Ok(()),
+                    -1 => Err(std::io::Error::last_os_error()),
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        let path = path.to_path_buf();
+        unsafe { self.pre_exec(move || chroot(&path)) }
+    }
+
+    fn current_dir(&mut self, path: &Path) -> &mut Self {
+        let path = path.to_path_buf();
+        unsafe { self.pre_exec(move || std::env::set_current_dir(&path)) }
     }
 }
 
@@ -308,10 +358,13 @@ pub(crate) async fn command_to_std(
         result.gid(x);
     }
     if let Some(x) = command.env.uid {
-        result.uid(x);
+        CommandExt::uid(&mut result, x);
+    }
+    if let Some(x) = &command.env.root_dir {
+        result.root_dir(x);
     }
     if let Some(x) = &command.env.working_dir {
-        result.current_dir(x);
+        CommandExt::current_dir(&mut result, x);
     }
     if command.env.clear_vars {
         result.env_clear();


### PR DESCRIPTION
This pull request implements #38, adding `chroot()` support.

Solving the problem of `setuid` order, this implemented `uid` via `.pre_exec()`.